### PR TITLE
43 validar e formatar campos de formulários cnpj telefone

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@ docker-compose up -d
 
 4. O Docker irá baixar as imagens necessárias e iniciar os containers
 
-5. Agora rode o comando:
+5. Agora rode o comando para instalar as dependências do CodeIgniter 4:
 ```bash
 docker exec -it -w /var/www/html vagas_app composer install
 ```
 
-6. O Composer irá instalar as dependências do CodeIgniter 4
+6. Crie o arquivo .env na raiz do seu projeto (copie o arquivo env padrão e renomeie para .env) e coloque as credenciais do banco de dados configuradas no seu docker-compose.
 
-7. Agora você pode acessar o projeto no navegador através do endereço: http://localhost:8080
+7. Crie o arquivo .env na raiz do seu projeto (copie o arquivo env padrão e renomeie para .env) e coloque as credenciais do banco de dados configuradas no seu docker-compose.
+```bash
+docker exec -it -w /var/www/html vagas_app php spark migrate
+```
+
+8. Agora você pode acessar o projeto no navegador através do endereço: http://localhost:8080

--- a/env
+++ b/env
@@ -1,0 +1,69 @@
+#--------------------------------------------------------------------
+# Example Environment Configuration file
+#
+# This file can be used as a starting point for your own
+# custom .env files, and contains most of the possible settings
+# available in a default install.
+#
+# By default, all of the settings are commented out. If you want
+# to override the setting, you must un-comment it by removing the '#'
+# at the beginning of the line.
+#--------------------------------------------------------------------
+
+#--------------------------------------------------------------------
+# ENVIRONMENT
+#--------------------------------------------------------------------
+
+# CI_ENVIRONMENT = production
+
+#--------------------------------------------------------------------
+# APP
+#--------------------------------------------------------------------
+
+# app.baseURL = ''
+# If you have trouble with `.`, you could also use `_`.
+# app_baseURL = ''
+# app.forceGlobalSecureRequests = false
+# app.CSPEnabled = false
+
+#--------------------------------------------------------------------
+# DATABASE
+#--------------------------------------------------------------------
+
+# database.default.hostname = localhost
+# database.default.database = ci4
+# database.default.username = root
+# database.default.password = root
+# database.default.DBDriver = MySQLi
+# database.default.DBPrefix =
+# database.default.port = 3306
+
+# If you use MySQLi as tests, first update the values of Config\Database::$tests.
+# database.tests.hostname = localhost
+# database.tests.database = ci4_test
+# database.tests.username = root
+# database.tests.password = root
+# database.tests.DBDriver = MySQLi
+# database.tests.DBPrefix =
+# database.tests.charset = utf8mb4
+# database.tests.DBCollat = utf8mb4_general_ci
+# database.tests.port = 3306
+
+#--------------------------------------------------------------------
+# ENCRYPTION
+#--------------------------------------------------------------------
+
+# encryption.key =
+
+#--------------------------------------------------------------------
+# SESSION
+#--------------------------------------------------------------------
+
+# session.driver = 'CodeIgniter\Session\Handlers\FileHandler'
+# session.savePath = null
+
+#--------------------------------------------------------------------
+# LOGGER
+#--------------------------------------------------------------------
+
+# logger.threshold = 4

--- a/src/app/Controllers/AuthController.php
+++ b/src/app/Controllers/AuthController.php
@@ -44,7 +44,7 @@ class AuthController extends BaseController
             'cnpj'     => preg_replace('/[^0-9]/', '', (string) $this->request->getPost('cnpj')),
             'endereco' => trim((string) $this->request->getPost('endereco')),
             'link'     =>  trim((string) $this->request->getPost('link')),
-            'senha'    => $this->request->getPost('senha'),
+            'senha' => password_hash((string) $this->request->getPost('senha'), PASSWORD_DEFAULT),
         ];
 
         if ($model->save($dados)) {

--- a/src/app/Controllers/AuthController.php
+++ b/src/app/Controllers/AuthController.php
@@ -38,12 +38,12 @@ class AuthController extends BaseController
         }
 
         $dados = [
-            'nome'     => $this->request->getPost('nome'),
-            'email'    => $this->request->getPost('email'),
-            'whatsapp' => $this->request->getPost('contato'),
-            'cnpj'     => $this->request->getPost('cnpj'),
-            'endereco' => $this->request->getPost('endereco'),
-            'link'     => $this->request->getPost('link'),
+            'nome'     => trim((string) $this->request->getPost('nome')),
+            'email'    => trim((string) $this->request->getPost('email')),
+            'whatsapp' => preg_replace('/[^0-9]/', '', (string) $this->request->getPost('contato')),
+            'cnpj'     => preg_replace('/[^0-9]/', '', (string) $this->request->getPost('cnpj')),
+            'endereco' => trim((string) $this->request->getPost('endereco')),
+            'link'     =>  trim((string) $this->request->getPost('link')),
             'senha'    => $this->request->getPost('senha'),
         ];
 
@@ -66,7 +66,7 @@ class AuthController extends BaseController
         }
 
         $model   = new EmpresaModel();
-        $cnpj    = $this->request->getPost('cnpj');
+        $cnpj    = preg_replace('/[^0-9]/', '', (string) $this->request->getPost('cnpj'));
         $senha   = (string) $this->request->getPost('senha');
         $empresa = $model->where('cnpj', $cnpj)->first();
 

--- a/src/app/Controllers/Empresas.php
+++ b/src/app/Controllers/Empresas.php
@@ -51,8 +51,8 @@ class Empresas extends BaseController
         $data = [
             'nome'     => trim((string) $this->request->getPost('nome_da_empresa')),
             'email'    => trim((string) $this->request->getPost('email')),
-            'whatsapp' => trim((string) $this->request->getPost('contato')),
-            'cnpj'     => trim((string) $this->request->getPost('cnpj')),
+            'whatsapp' => preg_replace('/[^0-9]/', '', (string) $this->request->getPost('contato')),
+            'cnpj'     => preg_replace('/[^0-9]/', '', (string) $this->request->getPost('cnpj')),
             'endereco' => trim((string) $this->request->getPost('endereco')),
             'link'     => trim((string) $this->request->getPost('link')),
         ];

--- a/src/app/Views/layouts/base.php
+++ b/src/app/Views/layouts/base.php
@@ -13,6 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://unpkg.com/imask"></script>
 
     <?= $this->renderSection('styles') ?>
     <?php include 'glass.php'; ?>
@@ -115,6 +116,16 @@
     </main>
 
     <?= $this->renderSection('scripts') ?>
+
+    <script>
+    IMask(document.getElementById('cnpj'), {
+        mask: '00.000.000/0000-00'
+    });
+
+    IMask(document.getElementById('contato'), {
+        mask: '(00) 00000-0000'
+    });
+    </script>
 
 </body>
 

--- a/src/app/Views/pages/cadastro.php
+++ b/src/app/Views/pages/cadastro.php
@@ -17,7 +17,6 @@
     <div class="alert success"><?= session()->getFlashdata('status') ?></div>
 <?php endif; ?>
 
-<script src="https://unpkg.com/imask"></script>
 
     <form action="<?= base_url('cadastro/salvar') ?>" method="post">
         <?= csrf_field() ?>
@@ -37,7 +36,7 @@
         <div class="letras-formulario">
             <label for="Instituicao">Instituição:</label>
             <div class="posicionamento-inputs">
-            <input class="input-duplo-formulario" type="text" id="cnpj" name="cnpj"  inputmode="numeric"  required placeholder="CNPJ" value="<?= old('cnpj') ?>">
+            <input class="input-duplo-formulario" type="text" id="cnpj" name="cnpj" inputmode="numeric"  required placeholder="CNPJ" value="<?= old('cnpj') ?>">
                 <input class="input-duplo-formulario" type="text" id="endereco" name="endereco" required placeholder="Endereço" value="<?= old('endereco') ?>">
             </div>
         </div>
@@ -61,17 +60,6 @@
         </div>
     </form>
 </div>
-
-<script>
-    IMask(document.getElementById('cnpj'), {
-        mask: '00.000.000/0000-00'
-    });
-
-    IMask(document.getElementById('contato'), {
-        mask: '(00) 00000-0000'
-    });
-</script>
-
 
 
 <?= $this->endSection() ?>

--- a/src/app/Views/pages/cadastro.php
+++ b/src/app/Views/pages/cadastro.php
@@ -17,6 +17,8 @@
     <div class="alert success"><?= session()->getFlashdata('status') ?></div>
 <?php endif; ?>
 
+<script src="https://unpkg.com/imask"></script>
+
     <form action="<?= base_url('cadastro/salvar') ?>" method="post">
         <?= csrf_field() ?>
 
@@ -35,7 +37,7 @@
         <div class="letras-formulario">
             <label for="Instituicao">Instituição:</label>
             <div class="posicionamento-inputs">
-                <input class="input-duplo-formulario" type="number" id="cnpj" name="cnpj" required placeholder="CNPJ" value="<?= old('cnpj') ?>">
+            <input class="input-duplo-formulario" type="text" id="cnpj" name="cnpj"  inputmode="numeric"  required placeholder="CNPJ" value="<?= old('cnpj') ?>">
                 <input class="input-duplo-formulario" type="text" id="endereco" name="endereco" required placeholder="Endereço" value="<?= old('endereco') ?>">
             </div>
         </div>
@@ -59,4 +61,17 @@
         </div>
     </form>
 </div>
+
+<script>
+    IMask(document.getElementById('cnpj'), {
+        mask: '00.000.000/0000-00'
+    });
+
+    IMask(document.getElementById('contato'), {
+        mask: '(00) 00000-0000'
+    });
+</script>
+
+
+
 <?= $this->endSection() ?>

--- a/src/app/Views/pages/empresas/edit.php
+++ b/src/app/Views/pages/empresas/edit.php
@@ -21,7 +21,7 @@
         <div class="letras-formulario">
             <label for="Instituicao">Instituição:</label>
             <div class="posicionamento-inputs">
-                <input class="input-duplo-formulario" type="text" id="cnpj" name="cnpj" value="<?= esc($empresa['cnpj'] ?? '') ?>" placeholder="CNPJ">
+                <input class="input-duplo-formulario" type="text" id="cnpj" name="cnpj" inputmode="numeric" value="<?= esc($empresa['cnpj'] ?? '') ?>" placeholder="CNPJ">
                 <input class="input-duplo-formulario" type="text" id="endereco" name="endereco" value="<?= esc($empresa['endereco'] ?? '') ?>" placeholder="Endereço">
             </div>
         </div>
@@ -29,7 +29,7 @@
         <div class="letras-formulario">
             <label for="Contato">Contato:</label>
             <div class="posicionamento-inputs">
-                <input class="input-duplo-formulario" type="text" id="contato" name="contato" value="<?= esc($empresa['whatsapp']) ?>" placeholder="Whatsapp">
+                <input class="input-duplo-formulario" type="text" id="contato" name="contato" inputmode="numeric" value="<?= esc($empresa['whatsapp']) ?>" placeholder="Whatsapp">
                 <input class="input-duplo-formulario" type="email" id="email" name="email" required value="<?= esc($empresa['email']) ?>" placeholder="Email">
             </div>
         </div>

--- a/src/app/Views/pages/login.php
+++ b/src/app/Views/pages/login.php
@@ -16,7 +16,7 @@
         <div class="letras-formulario">
             <label for="CNPJ">CNPJ:</label>
             <div class="posicionamento-inputs">
-                <input class="input-unico-formulario" type="number" id="cnpj" name="cnpj" required placeholder="CNPJ" value="<?= old('cnpj') ?>">
+                <input class="input-unico-formulario" type="text" id="cnpj" name="cnpj" inputmode="numeric" required placeholder="CNPJ" value="<?= old('cnpj') ?>">
             </div>
             <br>
             <label for="Senha">Senha:</label>


### PR DESCRIPTION
Agora quando o usuário tenta escrever nos campos de contato e CNPJ ele é obrigado a usar apenas números, e o campo se molda no padrão de cada campo.